### PR TITLE
Add iOS sample for air monitor

### DIFF
--- a/samples/air_monitor_ios/.gitignore
+++ b/samples/air_monitor_ios/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/samples/air_monitor_ios/Package.swift
+++ b/samples/air_monitor_ios/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "AirMonitor",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .iOSApplication(
+            name: "AirMonitor",
+            targets: ["AirMonitor"],
+            bundleIdentifier: "com.example.AirMonitor",
+            teamIdentifier: nil,
+            displayVersion: "1.0",
+            bundleVersion: "1",
+            appIcon: .placeholder(),
+            accentColor: .preset(.orange),
+            supportedDeviceFamilies: [
+                .phone
+            ],
+            supportedInterfaceOrientations: [
+                .portrait
+            ]
+        )
+    ],
+    targets: [
+        .executableTarget(
+            name: "AirMonitor",
+            path: "Sources",
+            resources: [
+                .process("Resources/Info.plist")
+            ]
+        )
+    ]
+)

--- a/samples/air_monitor_ios/README.md
+++ b/samples/air_monitor_ios/README.md
@@ -1,0 +1,16 @@
+# Air Monitor iOS App
+
+This sample contains a minimal iOS application written in SwiftUI. The app connects to an air quality sensor based on an nRF52840 board and reads data over Bluetooth Low Energy.
+
+## Setup
+
+1. Open `Package.swift` in Xcode 14 or later. Xcode will automatically generate a project from the Swift Package.
+2. Select a simulator or iOS device and build the `AirMonitor` scheme.
+
+The app scans for peripherals advertising the custom Air Quality Service UUID `0000A001-0000-1000-8000-00805F9B34FB` and reads three characteristics:
+
+- Temperature (UUID `0000A002-0000-1000-8000-00805F9B34FB`)
+- Humidity (UUID `0000A003-0000-1000-8000-00805F9B34FB`)
+- Formaldehyde (UUID `0000A004-0000-1000-8000-00805F9B34FB`)
+
+Update the UUIDs if your firmware uses different values.

--- a/samples/air_monitor_ios/Sources/AirMonitorApp.swift
+++ b/samples/air_monitor_ios/Sources/AirMonitorApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct AirMonitorApp: App {
+    @StateObject private var bluetooth = BluetoothManager()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(bluetooth)
+        }
+    }
+}

--- a/samples/air_monitor_ios/Sources/BluetoothManager.swift
+++ b/samples/air_monitor_ios/Sources/BluetoothManager.swift
@@ -1,0 +1,91 @@
+import Foundation
+import CoreBluetooth
+
+struct SensorValues {
+    var temperature: Double
+    var humidity: Double
+    var formaldehyde: Double
+}
+
+class BluetoothManager: NSObject, ObservableObject {
+    @Published var sensorValues: SensorValues?
+    @Published var isScanning = false
+
+    private var central: CBCentralManager!
+    private var peripheral: CBPeripheral?
+
+    // Example UUIDs
+    private let serviceUUID = CBUUID(string: "0000A001-0000-1000-8000-00805F9B34FB")
+    private let tempUUID = CBUUID(string: "0000A002-0000-1000-8000-00805F9B34FB")
+    private let humidityUUID = CBUUID(string: "0000A003-0000-1000-8000-00805F9B34FB")
+    private let formaldehydeUUID = CBUUID(string: "0000A004-0000-1000-8000-00805F9B34FB")
+
+    override init() {
+        super.init()
+        central = CBCentralManager(delegate: self, queue: nil)
+    }
+
+    func toggleScan() {
+        if isScanning {
+            central.stopScan()
+            isScanning = false
+        } else {
+            sensorValues = nil
+            central.scanForPeripherals(withServices: [serviceUUID], options: nil)
+            isScanning = true
+        }
+    }
+}
+
+extension BluetoothManager: CBCentralManagerDelegate, CBPeripheralDelegate {
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        if central.state != .poweredOn {
+            print("Bluetooth not available")
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String : Any], rssi RSSI: NSNumber) {
+        self.peripheral = peripheral
+        central.stopScan()
+        isScanning = false
+        central.connect(peripheral, options: nil)
+    }
+
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        peripheral.delegate = self
+        peripheral.discoverServices([serviceUUID])
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        guard let services = peripheral.services else { return }
+        for service in services where service.uuid == serviceUUID {
+            peripheral.discoverCharacteristics([tempUUID, humidityUUID, formaldehydeUUID], for: service)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        guard let chars = service.characteristics else { return }
+        for char in chars {
+            peripheral.readValue(for: char)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        guard let data = characteristic.value else { return }
+        let value = Double(Int16(bigEndian: data.withUnsafeBytes { $0.load(as: Int16.self) }))
+
+        switch characteristic.uuid {
+        case tempUUID:
+            if sensorValues == nil { sensorValues = SensorValues(temperature: value / 100, humidity: 0, formaldehyde: 0) }
+            else { sensorValues?.temperature = value / 100 }
+        case humidityUUID:
+            if sensorValues == nil { sensorValues = SensorValues(temperature: 0, humidity: value / 100, formaldehyde: 0) }
+            else { sensorValues?.humidity = value / 100 }
+        case formaldehydeUUID:
+            if sensorValues == nil { sensorValues = SensorValues(temperature: 0, humidity: 0, formaldehyde: value / 1000) }
+            else { sensorValues?.formaldehyde = value / 1000 }
+        default:
+            break
+        }
+    }
+}

--- a/samples/air_monitor_ios/Sources/ContentView.swift
+++ b/samples/air_monitor_ios/Sources/ContentView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject var bluetooth: BluetoothManager
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Air Monitor")
+                .font(.title)
+            if let values = bluetooth.sensorValues {
+                Text(String(format: "Temperature: %.1f °C", values.temperature))
+                Text(String(format: "Humidity: %.1f %%", values.humidity))
+                Text(String(format: "Formaldehyde: %.2f ppm", values.formaldehyde))
+            } else {
+                Text("Scanning for device...")
+            }
+            Button(bluetooth.isScanning ? "Stop Scan" : "Start Scan") {
+                bluetooth.toggleScan()
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(BluetoothManager())
+}

--- a/samples/air_monitor_ios/Sources/Resources/Info.plist
+++ b/samples/air_monitor_ios/Sources/Resources/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.AirMonitor</string>
+    <key>CFBundleName</key>
+    <string>AirMonitor</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>Used to connect to the air monitor.</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add `samples/air_monitor_ios` SwiftUI package
- implement basic Bluetooth manager and UI to read temperature, humidity, and formaldehyde

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_687f98e23f2c832d9226717760df6e89